### PR TITLE
fix para name

### DIFF
--- a/jrpc/RpcError.h
+++ b/jrpc/RpcError.h
@@ -33,8 +33,8 @@ public:
             err_(err)
     {}
 
-    explicit RpcError(int32_t errorCode):
-            err_(fromErrorCode(errorCode))
+    explicit RpcError(int32_t errCode):
+            err_(fromErrorCode(errCode))
     {}
 
     const char* asString() const


### PR DESCRIPTION
这里的errorCode变量名与类成员相同，在一些编译器中会出现 
`error: declaration of ‘errorCode’ shadows a member of ‘jrpc::RpcError’ [-Werror=shadow]
`